### PR TITLE
Feature: Show EPP token (if supported)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [Unreleased]
+### Added
+
+- Add `domain_epp_show` command to the `Domain` endpoint to retrieve the EPP code for a domain.
+
 ## [2.13.1]
 
 ### Fixed

--- a/src/Endpoints/DomainEndpoint.php
+++ b/src/Endpoints/DomainEndpoint.php
@@ -269,6 +269,36 @@ class DomainEndpoint extends Endpoint implements EndpointContract
     }
 
     /**
+     * Show the EPP token. (The TLD must support this.)
+     *
+     * @throws OxxaException
+     */
+    public function showEpp(string $sld, string $tld): OxxaResult
+    {
+        $xml = $this
+            ->client
+            ->request([
+                'command' => 'domain_epp_show',
+                'sld' => $sld,
+                'tld' => $tld,
+            ]);
+
+        $statusCode = $this->getStatusCode($xml);
+        $statusDescription = $this->getStatusDescription($xml);
+
+        return new OxxaResult(
+            success: $statusCode === StatusCode::STATUS_DOMAIN_TOKEN_RETRIEVED,
+            message: $statusDescription,
+            data: [
+                'epp' => $xml->filter('channel > order > details')->count()
+                    ? $xml->filter('channel > order > details')->text()
+                    : null,
+            ],
+            status: $statusCode,
+        );
+    }
+
+    /**
      * Update the domain. Be aware, when changing the identity-registrant some TLD's handle this as a transfer to a new
      * account. The TLD might charge you for that.
      *

--- a/src/Enum/StatusCode.php
+++ b/src/Enum/StatusCode.php
@@ -10,6 +10,8 @@ class StatusCode
 
     public const STATUS_DOMAIN_LOCK_CHANGED = 'XMLOK 3';
 
+    public const STATUS_DOMAIN_TOKEN_RETRIEVED = 'XMLOK 136';
+
     public const STATUS_DOMAIN_TOKEN_SENT = 'XMLOK 39';
 
     public const STATUS_DOMAIN_UPDATED = 'XMLOK 12';

--- a/tests/Fakes/DomainEppShowResponse.php
+++ b/tests/Fakes/DomainEppShowResponse.php
@@ -2,7 +2,7 @@
 
 namespace Cyberfusion\Oxxa\Tests\Fakes;
 
-class DomainEppSentResponse
+class DomainEppShowResponse
 {
     public function body(): string
     {

--- a/tests/Fakes/DomainEppShowResponse.php
+++ b/tests/Fakes/DomainEppShowResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Cyberfusion\Oxxa\Tests\Fakes;
+
+class DomainEppSentResponse
+{
+    public function body(): string
+    {
+        return '<?xml version="1.0" encoding="ISO-8859-1" ?>
+            <channel>
+                <order>
+                    <order_id>123456</order_id>
+                    <command>domain_epp_show</command>
+                    <sld>example</sld>
+                    <tld>org</tld>
+                    <status_code>XMLOK 136</status_code>
+                    <status_description>De verhuiscode is opgehaald.</status_description>
+                    <price />
+                    <details>EPPCODE</details>
+                    <order_complete>TRUE</order_complete>
+                    <done>TRUE</done>
+                </order>
+            </channel>';
+    }
+}

--- a/tests/Unit/DomainTest.php
+++ b/tests/Unit/DomainTest.php
@@ -227,6 +227,27 @@ class DomainTest extends TestCase
         });
     }
 
+    public function test_it_can_show_epp(): void
+    {
+        $this->httpClient->fake(fn(Request $request) => Factory::response((new DomainEppShowResponse())->body()));
+
+        $tokenSent = $this
+            ->oxxa
+            ->domain()
+            ->showEpp('example', 'org');
+
+        $this->assertTrue($tokenSent->success());
+        $this->httpClient->assertSent(function (Request $request) {
+            return $request->method() === 'GET' &&
+                Arr::get($request->data(), 'command') === 'domain_epp_show' &&
+                Arr::get($request->data(), 'sld') === 'example' &&
+                Arr::get($request->data(), 'tld') === 'org' &&
+                Arr::get($request->data(), 'apiuser') === 'USER' &&
+                Arr::get($request->data(), 'apipassword') === 'PASS' &&
+                Arr::get($request->data(), 'test') === null;
+        });
+    }
+
     public function test_it_can_retrieve_domain_information(): void
     {
         $this->httpClient->fake(fn(Request $request) => Factory::response((new DomainInformationResponse())->body()));

--- a/tests/Unit/DomainTest.php
+++ b/tests/Unit/DomainTest.php
@@ -10,6 +10,7 @@ use Cyberfusion\Oxxa\Requests\DomainListRequest;
 use Cyberfusion\Oxxa\Tests\Fakes\DomainAutoRenewResponse;
 use Cyberfusion\Oxxa\Tests\Fakes\DomainDeletedResponse;
 use Cyberfusion\Oxxa\Tests\Fakes\DomainEppSentResponse;
+use Cyberfusion\Oxxa\Tests\Fakes\DomainEppShowResponse;
 use Cyberfusion\Oxxa\Tests\Fakes\DomainInformationResponse;
 use Cyberfusion\Oxxa\Tests\Fakes\DomainListResponse;
 use Cyberfusion\Oxxa\Tests\Fakes\DomainLockResponse;


### PR DESCRIPTION
Oxxa implements an undocumented API command, `domain_epp_show` which shows the EPP token IF the TLD supports this.