### PR TITLE
Remove unnecessary 'xxxMemberId' and 'xxxPassword' fields from Identity model and IdentityEndpoint

### DIFF
--- a/src/Endpoints/IdentityEndpoint.php
+++ b/src/Endpoints/IdentityEndpoint.php
@@ -47,8 +47,6 @@ class IdentityEndpoint extends Endpoint implements EndpointContract
                     alias: $identityNode->filter('alias')->text(),
                     companyName: $identityNode->filter('company_name')->text(),
                     name: $identityNode->filter('name')->text(),
-                );
-            });
 
         return new OxxaResult(
             success: true,
@@ -121,8 +119,6 @@ class IdentityEndpoint extends Endpoint implements EndpointContract
                 ? DateTime::createFromFormat('d-m-Y', $detailsNode->filter('idcarddate')->text())->setTime(0, 0)
                 : null,
             idCardIssuer: $detailsNode->filter('idcardissuer')->text(),
-            xxxMemberId: $detailsNode->filter('xxxmemberid')->text(),
-            xxxPassword: $detailsNode->filter('xxxpassword')->text(),
             ensId: $detailsNode->filter('ens_id')->text(),
             ensPassword: $detailsNode->filter('ens_password')->text(),
             profession: $detailsNode->filter('profession')->text(),

--- a/src/Models/Identity.php
+++ b/src/Models/Identity.php
@@ -43,10 +43,7 @@ class Identity implements Model
         public ?string $trademarkName = null,
         public ?DateTimeInterface $idCardDate = null,
         public ?string $idCardIssuer = null,
-        public ?string $xxxMemberId = null,
-        public ?string $xxxPassword = null,
         public ?string $ensId = null,
-        public ?string $ensPassword = null,
         public ?string $profession = null,
         public ?string $travelUinId = null,
     ) {
@@ -102,8 +99,6 @@ class Identity implements Model
                 ->idCardDate
                 ?->format('d-m-Y'),
             'idcardissuer' => $this->idCardIssuer,
-            'xxxmemberid' => $this->xxxMemberId,
-            'xxxpassword' => $this->xxxPassword,
             'ens_id' => $this->ensId,
             'ens_password' => $this->ensPassword,
             'profession' => $this->profession,


### PR DESCRIPTION
This pull request removes support for the deprecated `xxxMemberId` and `xxxPassword` fields from the identity model and related endpoints. The changes simplify the codebase and ensure that only relevant fields are handled in identity operations.

**Identity Model Cleanup:**

* Removed the `xxxMemberId` and `xxxPassword` properties from the `Identity` model's constructor and serialization logic in `src/Models/Identity.php`. [[1]](diffhunk://#diff-ea9c7315d141bc69f72a7d86a9c0c642b683f4d28e1d6d2d5ae3759eb3784dfdL46-L49) [[2]](diffhunk://#diff-ea9c7315d141bc69f72a7d86a9c0c642b683f4d28e1d6d2d5ae3759eb3784dfdL105-L106)

**Endpoint Updates:**

* Removed handling of `xxxMemberId` and `xxxPassword` fields from the `get` method in `src/Endpoints/IdentityEndpoint.php`.
* Removed references to deprecated fields in the identity listing logic in `src/Endpoints/IdentityEndpoint.php`.

**Related**
Closes #3 